### PR TITLE
Test fail fix

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -26,7 +26,7 @@ command-line invocation.
     # Heavy-duty training interface. Backends may drop some safety
     # features like journals or synchronous IO to train faster using
     # this mode.
-    $hailo->train("megahal.trn");
+    $hailo->train("badger.trn");
     $hailo->train($filehandle);
 
     # Make the brain babble
@@ -286,4 +286,3 @@ E<AElig>var ArnfjE<ouml>rE<eth> Bjarmason <avar@cpan.org>
 This program is free software, you can redistribute it and/or modify
 it under the same terms as Perl itself.
 
-=cut

--- a/dist.ini
+++ b/dist.ini
@@ -70,7 +70,7 @@ Test::More                = 0.94
 Test::Output              = 0.16
 Test::Script              = 1.07
 Test::Script::Run         = 0.04
-Test::Synopsis            = 0.06
+Pod::Section		  = 0.01
 Data::Section             = 0.101620
 
 ; Data to babble on

--- a/lib/Hailo.pm
+++ b/lib/Hailo.pm
@@ -370,7 +370,7 @@ command-line invocation.
     # Heavy-duty training interface. Backends may drop some safety
     # features like journals or synchronous IO to train faster using
     # this mode.
-    $hailo->train("megahal.trn");
+    $hailo->train("badger.trn");
     $hailo->train($filehandle);
 
     # Make the brain babble

--- a/t/hailo/synopsis.t
+++ b/t/hailo/synopsis.t
@@ -1,15 +1,15 @@
 use 5.010;
 use strict;
 use warnings;
-use Test::Synopsis;
+use Pod::Section qw(select_podsection);
 use Test::More tests => 1;
 
-my ($synopsis) = Test::Synopsis::extract_synopsis('lib/Hailo.pm');
+my ($synopsis) = select_podsection('lib/Hailo.pm' , 'SYNOPSIS');
 $synopsis =~ s/^.*?(?=\s+use)//s;
 
 local $@;
-eval <<'SYNOPSIS';
-open my $filehandle, '<', __FILE__;
+eval <<SYNOPSIS;
+open my \$filehandle, '<', __FILE__;
 chdir 't/lib/Hailo/Test';
 $synopsis
 SYNOPSIS


### PR DESCRIPTION
CPAN PRC :-)

Test script:
t/hailo/synopsis.t'

Test fail example:
http://www.cpantesters.org/cpan/report/92920996-f531-11e5-bf19-899010d7819d

extract_synopsis subroutine from Test::Synopsis is private. It was rewritten and renamed in 0.14 release of Test::Synopsis.

I decided to replace Test::Synopsis with: Pod::Section - which exports "select_podsection" subroutine that will get synopsis pod section the same way.

I also updated the heredoc - looks like it did not interpolate the $synopsis variable since it acted as a single quoted string.
